### PR TITLE
fix: navbar overlaps content heading when opening a page at specific section

### DIFF
--- a/src/components/Markdown.module.css
+++ b/src/components/Markdown.module.css
@@ -46,7 +46,7 @@
 }
 
 .content *[id] {
-  scroll-margin-top: var(--spacing-4);
+  scroll-margin-top: 70px; /* same as the navbar height */
 }
 
 .content ul {


### PR DESCRIPTION
### Problem:
When opening any site like https://umami.is/docs#hosting, the navbar overlaps the hosting header because the scroll margin is too small.

### Solution:
Change the scroll-margin-top value to at least 70px (navbar height).

**Here are two images before and after my changes**
![before-commit](https://github.com/user-attachments/assets/6ee8e45e-af27-4eb8-b2a4-9d694d11f831)
![after-commit](https://github.com/user-attachments/assets/97f41a27-e492-45b6-b53c-277d9b7b9a67)